### PR TITLE
[KR] 6.0 location per KR2022 Fan Festival

### DIFF
--- a/Data/DcDuty-Korean.json
+++ b/Data/DcDuty-Korean.json
@@ -1648,7 +1648,7 @@
       }
     },
     "956": {
-      "name": "6.0/라비린소스",
+      "name": "6.0/라비린토스",
       "fates": {
         "1743": "Incident Files: Seeds of Chaos",
         "1744": "Incident Files: Steamed Vegetable",
@@ -1669,7 +1669,7 @@
       }
     },
     "957": {
-      "name": "6.0/사베네어",
+      "name": "6.0/사베네어 섬",
       "fates": {
         "1763": "Devout Pilgrims vs. Daivadipa",
         "1764": "Full Petal Alchemist: Perilous Pickings",


### PR DESCRIPTION
팬페에서 공개된 지명 기준입니다. 나머지는 뭐... 5월 10일에 공개됩니다 (두둥)

갈레말드는 갈레말드여서 스킵.

+ "비탄의 바다" 라는 지명도 공개되어있는데 (아무래도 글섭을 안 하는 입장이다보니) 스포방지 1/2/3 중 어느 것이 비탄인지 모르겠어서 추후에 적절히 수정해주시면 감사합니다.